### PR TITLE
refactor: reduce cloning in assets

### DIFF
--- a/crates/maudit/src/content/markdown.rs
+++ b/crates/maudit/src/content/markdown.rs
@@ -367,7 +367,7 @@ pub fn render_markdown(
                             let resolved = parent.join(dest_url.to_string());
                             route_ctx
                                 .as_mut()
-                                .and_then(|ctx| ctx.assets.add_image(resolved).url())
+                                .and_then(|ctx| ctx.assets.add_image(resolved).url().cloned())
                         })
                         .map(|image_url| {
                             Event::Start(Tag::Image {


### PR DESCRIPTION
We can safely assume that both the build_path and the url of an asset will always be used (otherwise, why would they be added in the first place), so we might as well calculate it upfront and avoid clumsily storing the world in every asset 