### PR TITLE
small docs fixes

### DIFF
--- a/website/content/docs/manual-install.md
+++ b/website/content/docs/manual-install.md
@@ -10,11 +10,12 @@ cargo new my-website --bin
 cd my-website
 ```
 
-Next, add Maudit as a dependency in your `Cargo.toml` file, or run `cargo add maudit` to do so automatically:
+Next, add Maudit as a dependency in your `Cargo.toml` file, or run `cargo add maudit` to do so automatically. You might also want to add [Maud](https://maud.lambda.xyz/) as a dependency if you plan to use it for templating.
 
 ```toml
 [dependencies]
 maudit = "0.6"
+maud = "0.27" # optional
 ```
 
 Voilà! You can now use Maudit in your project. Check out the rest of the [documentation](/docs) for more information on how to use Maudit, or if you prefer jumping straght into the code, take a look at the [examples](https://github.com/bruits/maudit/tree/main/examples) and the [API documentation](https://docs.rs/maudit).

--- a/website/content/docs/quick-start.md
+++ b/website/content/docs/quick-start.md
@@ -5,7 +5,7 @@ section: "getting-started"
 
 In this guide, you'll learn how to create a Maudit website and the general basis of Maudit in a few minutes of reading.
 
-If you prefer to read more detailed explanations, including exploration of various Maudit concepts, please read the [the tutorial]().
+If you prefer to read more detailed explanations, including exploration of various Maudit concepts, please read the [core concepts](/docs/content/).
 
 **This guide assumes that you have Rust installed and are familiar with the terminal.**
 
@@ -72,7 +72,7 @@ use maudit::{coronate, routes, content_sources, BuildOptions, BuildOutput};
 
 fn main() -> Result<BuildOutput, Box<dyn std::error::Error>> {
     coronate(
-      routes![Index],
+      routes![HelloWorld],
       content_sources![],
       BuildOptions::default()
     )


### PR DESCRIPTION

## What does this change?

In `quick-start.md`:
- Fixed typo in code snippet at the bottom (non-existent `Index` → `HelloWorld`).
- Updated empty "the tutorial" link to instead point to the first page under "Core Concepts".

In `manual-install.md`:
- Added mention of Maud because it is used elsewhere in docs and it wasn't clear if it needs a separate install.

## How is it tested?

N/A

## How is it documented?

N/A