### PR TITLE
chore(fix): check script

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
 	/* Retry on CI only */
 	retries: process.env.CI ? 2 : 0,
 	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
+	workers: process.env.CI ? 1 : 0,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	// `html` opens a local report server after the run (locally useful, hangs in CI).
 	// `github` writes inline annotations and exits cleanly.

--- a/e2e/tests/prefetch.spec.ts
+++ b/e2e/tests/prefetch.spec.ts
@@ -62,7 +62,7 @@ test.describe("Prefetch", () => {
 			// Should only have one speculation rules script
 			const speculationScripts = await page.locator('script[type="speculationrules"]').all();
 			expect(speculationScripts.length).toBe(1);
-			const scriptContent = await speculationScripts[0].textContent();
+			const scriptContent = await speculationScripts[0]?.textContent();
 			if (scriptContent) {
 				const rules = JSON.parse(scriptContent);
 				expect(rules.prefetch).toBeDefined();

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"extends": "../tsconfig.json",
 	"compilerOptions": {
 		"target": "ES2022",
 		"module": "ES2022",
@@ -8,7 +9,8 @@
 		"skipLibCheck": true,
 		"resolveJsonModule": true,
 		"esModuleInterop": true,
-		"types": ["node", "@playwright/test"]
+		"types": ["node", "@playwright/test"],
+		"noEmit": true
 	},
 	"include": ["tests/**/*", "playwright.config.ts", "types.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"check": "pnpm run check:js && pnpm run check:rs",
-		"check:ts": "tsgo",
+		"check": "pnpm run check:ts && pnpm run check:rs",
+		"check:ts": "tsgo --project tsconfig.check.json && tsgo --project e2e",
 		"check:rs": "cargo check",
 		"lint": "pnpm run lint:ts && pnpm run lint:rs",
 		"lint:ts": "oxlint --type-aware",

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["./e2e", "node_modules", "dist", "vendor"]
+}


### PR DESCRIPTION
Fixes the `pnpm check` script by updating the `check:js` to `check:ts` and fixing the subsequent type errors.

e2e has extra `types` configured so must be checked separately from the rest of the project. For posterity, the alternative solution I found was to use TypeScript references.

<details>
<summary>references.patch</summary>

```patch
diff --git a/crates/maudit-cli/tsconfig.json b/crates/maudit-cli/tsconfig.json
index ca9b44a..0a3d685 100644
--- a/crates/maudit-cli/tsconfig.json
+++ b/crates/maudit-cli/tsconfig.json
@@ -1,4 +1,5 @@
 {
 	"extends": "../../tsconfig.json",
+	"compilerOptions": { "composite": true, "noEmit": false },
 	"include": ["js"]
 }
diff --git a/crates/maudit/tsconfig.json b/crates/maudit/tsconfig.json
index ca9b44a..0a3d685 100644
--- a/crates/maudit/tsconfig.json
+++ b/crates/maudit/tsconfig.json
@@ -1,4 +1,5 @@
 {
 	"extends": "../../tsconfig.json",
+	"compilerOptions": { "composite": true, "noEmit": false },
 	"include": ["js"]
 }
diff --git a/e2e/tsconfig.json b/e2e/tsconfig.json
index e6a83e1..31efbd6 100644
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"extends": "../tsconfig.json",
 	"compilerOptions": {
 		"target": "ES2022",
 		"module": "ES2022",
@@ -8,7 +9,9 @@
 		"skipLibCheck": true,
 		"resolveJsonModule": true,
 		"esModuleInterop": true,
-		"types": ["node", "@playwright/test"]
+		"types": ["node", "@playwright/test"],
+		"noEmit": false,
+		"composite": true
 	},
 	"include": ["tests/**/*", "playwright.config.ts", "types.d.ts"]
 }
diff --git a/package.json b/package.json
index 2c34efa..7d5aca7 100644
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"check": "pnpm run check:js && pnpm run check:rs",
+		"check": "pnpm run check:ts && pnpm run check:rs",
 		"check:ts": "tsgo",
 		"check:rs": "cargo check",
 		"lint": "pnpm run lint:ts && pnpm run lint:rs",
diff --git a/tsconfig.json b/tsconfig.json
index 14b5bce..87ee93c 100644
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,10 @@
 		"moduleDetection": "force",
 		"skipLibCheck": true
 	},
-	"exclude": ["node_modules", "dist", "vendor"]
+	"exclude": ["node_modules", "dist", "vendor"],
+	"references": [
+		{ "path": "./e2e" },
+		{ "path": "./crates/maudit" },
+		{ "path": "./crates/maudit-cli" }
+	]
 }
```

</details>