### PR TITLE
fix(bundling): Rebundle when an imported script or style dependency changes

### DIFF
--- a/.sampo/changesets/steadfast-weaver-ilmatar.md
+++ b/.sampo/changesets/steadfast-weaver-ilmatar.md
@@ -1,0 +1,5 @@
+---
+cargo/maudit: patch
+---
+
+Fixes incremental builds serving a stale bundle when a file imported by a script or stylesheet changed.

--- a/crates/maudit/src/assets/css.rs
+++ b/crates/maudit/src/assets/css.rs
@@ -2,8 +2,9 @@ use crate::errors::AssetError;
 use std::convert::Infallible;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
-use lightningcss::bundler::{Bundler, FileProvider};
+use lightningcss::bundler::{Bundler, FileProvider, ResolveResult, SourceProvider};
 use lightningcss::printer::PrinterOptions;
 use lightningcss::stylesheet::{MinifyOptions, ParserOptions, StyleSheet};
 use lightningcss::values::url::Url;
@@ -24,6 +25,50 @@ pub struct BundleCssOutput {
     /// Canonical paths of source files referenced via `url()` in the CSS.
     /// Used to detect when referenced assets change between builds.
     pub source_dependencies: Vec<PathBuf>,
+    /// Paths of every stylesheet the bundler read, i.e. the entry plus its transitive
+    /// `@import` graph. Imported partials are inlined into the output, so a change to
+    /// one alters the bundled bytes without touching the entry file's hash.
+    pub import_dependencies: Vec<PathBuf>,
+}
+
+/// Wraps [`FileProvider`] to record the path of every stylesheet the bundler reads,
+/// which is exactly the entry plus its transitive `@import` graph.
+struct RecordingFileProvider {
+    inner: FileProvider,
+    read_paths: Mutex<Vec<PathBuf>>,
+}
+
+impl RecordingFileProvider {
+    fn new() -> Self {
+        Self {
+            inner: FileProvider::new(),
+            read_paths: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn into_read_paths(self) -> Vec<PathBuf> {
+        self.read_paths.into_inner().unwrap_or_default()
+    }
+}
+
+impl SourceProvider for RecordingFileProvider {
+    type Error = std::io::Error;
+
+    fn read<'a>(&'a self, file: &Path) -> Result<&'a str, Self::Error> {
+        let source = self.inner.read(file)?;
+        if let Ok(paths) = self.read_paths.lock().as_mut() {
+            paths.push(file.to_path_buf());
+        }
+        Ok(source)
+    }
+
+    fn resolve(
+        &self,
+        specifier: &str,
+        originating_file: &Path,
+    ) -> Result<ResolveResult, Self::Error> {
+        self.inner.resolve(specifier, originating_file)
+    }
 }
 
 /// Visitor that rewrites relative `url()` references in CSS.
@@ -132,6 +177,8 @@ pub fn bundle_css(
         errors: Vec::new(),
     };
 
+    let mut import_dependencies = Vec::new();
+
     let code = if let Some(css) = source_css {
         let mut stylesheet = StyleSheet::parse(css, ParserOptions::default())
             .map_err(|e| format!("Failed to parse CSS: {}", e))?;
@@ -152,7 +199,7 @@ pub fn bundle_css(
             .map_err(|e| format!("Failed to serialize CSS: {}", e))?
             .code
     } else {
-        let provider = FileProvider::new();
+        let provider = RecordingFileProvider::new();
         let mut bundler = Bundler::new(&provider, None, ParserOptions::default());
 
         let mut stylesheet = bundler
@@ -167,13 +214,20 @@ pub fn bundle_css(
                 .map_err(|e| format!("Failed to minify CSS: {}", e))?;
         }
 
-        stylesheet
+        let code = stylesheet
             .to_css(PrinterOptions {
                 minify,
                 ..Default::default()
             })
             .map_err(|e| format!("Failed to serialize CSS: {}", e))?
-            .code
+            .code;
+
+        // Drop the borrow held by `bundler`/`stylesheet` before reclaiming the paths.
+        drop(stylesheet);
+        drop(bundler);
+        import_dependencies = provider.into_read_paths();
+
+        code
     };
 
     if let Some(err) = url_visitor.errors.into_iter().next() {
@@ -184,6 +238,7 @@ pub fn bundle_css(
         code,
         copied_asset_filenames: url_visitor.copied_filenames,
         source_dependencies: url_visitor.source_deps,
+        import_dependencies,
     })
 }
 

--- a/crates/maudit/src/assets/css.rs
+++ b/crates/maudit/src/assets/css.rs
@@ -25,14 +25,11 @@ pub struct BundleCssOutput {
     /// Canonical paths of source files referenced via `url()` in the CSS.
     /// Used to detect when referenced assets change between builds.
     pub source_dependencies: Vec<PathBuf>,
-    /// Paths of every stylesheet the bundler read, i.e. the entry plus its transitive
-    /// `@import` graph. Imported partials are inlined into the output, so a change to
-    /// one alters the bundled bytes without touching the entry file's hash.
+    /// The entry plus its transitive `@import` graph. Imported partials are inlined
+    /// into the output, so editing one changes the bundled bytes but not the entry's hash.
     pub import_dependencies: Vec<PathBuf>,
 }
 
-/// Wraps [`FileProvider`] to record the path of every stylesheet the bundler reads,
-/// which is exactly the entry plus its transitive `@import` graph.
 struct RecordingFileProvider {
     inner: FileProvider,
     read_paths: Mutex<Vec<PathBuf>>,
@@ -222,7 +219,7 @@ pub fn bundle_css(
             .map_err(|e| format!("Failed to serialize CSS: {}", e))?
             .code;
 
-        // Drop the borrow held by `bundler`/`stylesheet` before reclaiming the paths.
+        // `bundler` borrows `provider`.
         drop(stylesheet);
         drop(bundler);
         import_dependencies = provider.into_read_paths();

--- a/crates/maudit/src/build.rs
+++ b/crates/maudit/src/build.rs
@@ -1214,8 +1214,6 @@ pub async fn build(
                             cache.css_url_dependencies.insert(dep_path.clone(), fp);
                         }
                     }
-                    // `@import`-ed partials are inlined into the output, so they change
-                    // the bundled bytes without changing the entry stylesheet's hash.
                     for dep_path in &css_output.import_dependencies {
                         if let Some(fp) = cache::AssetFileFingerprint::from_path(dep_path) {
                             cache.style_import_dependencies.insert(dep_path.clone(), fp);
@@ -1309,10 +1307,6 @@ pub async fn build(
                             script_substitutions.insert(script.url.clone(), final_url);
                         }
 
-                        // Fingerprint the chunk's source module graph. The entry script's
-                        // own hash covers only the entry file, so without this an edit to
-                        // an imported module never triggers a rebundle. Modules that
-                        // aren't real files (virtual/plugin-generated) are skipped.
                         if let Some(ref mut cache) = new_cache {
                             for module_id in &chunk.module_ids {
                                 let path = PathBuf::from(module_id.as_str());

--- a/crates/maudit/src/build.rs
+++ b/crates/maudit/src/build.rs
@@ -1104,8 +1104,12 @@ pub async fn build(
                 &prev.bundled_styles,
                 &current_bundled_scripts,
                 &current_bundled_styles,
-                &prev.css_url_dependencies,
-                &prev.script_asset_dependencies,
+                &cache::CachedBundleDependencies {
+                    css_urls: &prev.css_url_dependencies,
+                    script_assets: &prev.script_asset_dependencies,
+                    script_modules: &prev.script_module_dependencies,
+                    style_imports: &prev.style_import_dependencies,
+                },
             )
         } else {
             true
@@ -1210,6 +1214,13 @@ pub async fn build(
                             cache.css_url_dependencies.insert(dep_path.clone(), fp);
                         }
                     }
+                    // `@import`-ed partials are inlined into the output, so they change
+                    // the bundled bytes without changing the entry stylesheet's hash.
+                    for dep_path in &css_output.import_dependencies {
+                        if let Some(fp) = cache::AssetFileFingerprint::from_path(dep_path) {
+                            cache.style_import_dependencies.insert(dep_path.clone(), fp);
+                        }
+                    }
                 }
             }
         }
@@ -1285,9 +1296,10 @@ pub async fn build(
                 current_output_files.insert(filename.clone());
 
                 match output {
-                    // Map `Script::url` → the content-hashed URL Rolldown wrote.
-                    rolldown_common::Output::Chunk(chunk) if chunk.is_entry => {
-                        if let Some(facade) = chunk.facade_module_id.as_ref()
+                    rolldown_common::Output::Chunk(chunk) => {
+                        // Map `Script::url` → the content-hashed URL Rolldown wrote.
+                        if chunk.is_entry
+                            && let Some(facade) = chunk.facade_module_id.as_ref()
                             && let Some(script) = scripts_by_path.get(facade.as_str())
                         {
                             let final_url = make_final_url(
@@ -1295,6 +1307,22 @@ pub async fn build(
                                 Path::new(&filename),
                             );
                             script_substitutions.insert(script.url.clone(), final_url);
+                        }
+
+                        // Fingerprint the chunk's source module graph. The entry script's
+                        // own hash covers only the entry file, so without this an edit to
+                        // an imported module never triggers a rebundle. Modules that
+                        // aren't real files (virtual/plugin-generated) are skipped.
+                        if let Some(ref mut cache) = new_cache {
+                            for module_id in &chunk.module_ids {
+                                let path = PathBuf::from(module_id.as_str());
+                                if !path.is_file() {
+                                    continue;
+                                }
+                                if let Some(fp) = cache::AssetFileFingerprint::from_path(&path) {
+                                    cache.script_module_dependencies.insert(path, fp);
+                                }
+                            }
                         }
                     }
                     // Fingerprint each Rolldown-emitted asset (WASM, images, fonts) so
@@ -1309,7 +1337,6 @@ pub async fn build(
                             }
                         }
                     }
-                    _ => {}
                 }
             }
         }
@@ -1346,6 +1373,8 @@ pub async fn build(
             cache.bundled_output_files = prev_cache.bundled_output_files.clone();
             cache.css_url_dependencies = prev_cache.css_url_dependencies.clone();
             cache.script_asset_dependencies = prev_cache.script_asset_dependencies.clone();
+            cache.script_module_dependencies = prev_cache.script_module_dependencies.clone();
+            cache.style_import_dependencies = prev_cache.style_import_dependencies.clone();
             cache.script_substitutions = prev_cache.script_substitutions.clone();
             cache.style_substitutions = prev_cache.style_substitutions.clone();
             script_substitutions = prev_cache.script_substitutions.clone();

--- a/crates/maudit/src/build/cache.rs
+++ b/crates/maudit/src/build/cache.rs
@@ -8,7 +8,7 @@ use log::{debug, info};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
-pub const BUILD_CACHE_VERSION: u32 = 13;
+pub const BUILD_CACHE_VERSION: u32 = 14;
 pub const BUILD_CACHE_FILENAME: &str = "build_cache.bin";
 
 /// Fingerprint for an asset file (script, style, image) used for fast change detection.
@@ -87,6 +87,16 @@ pub struct BuildCache {
     /// bytes even when no JS source changed, so we must re-bundle.
     #[serde(default)]
     pub script_asset_dependencies: FxHashMap<PathBuf, AssetFileFingerprint>,
+    /// Fingerprints of every on-disk module Rolldown inlined into a chunk, i.e. the
+    /// entry's transitive `import` graph. The entry script's own hash only covers the
+    /// entry file, so without this an edit to an imported module is invisible.
+    #[serde(default)]
+    pub script_module_dependencies: FxHashMap<PathBuf, AssetFileFingerprint>,
+    /// Fingerprints of CSS files pulled in via `@import`. Same blind spot as
+    /// `script_module_dependencies`: the stylesheet's hash covers only the entry file,
+    /// and `css_url_dependencies` only covers `url()` targets.
+    #[serde(default)]
+    pub style_import_dependencies: FxHashMap<PathBuf, AssetFileFingerprint>,
     /// Persisted asset hash cache: path → list of (options_hash, asset_hash, mtime, size).
     /// Used to skip `calculate_hash` on incremental rebuilds when the file hasn't changed.
     #[serde(default)]
@@ -523,14 +533,29 @@ pub fn find_stale_static_files(
         .collect()
 }
 
+/// The cached fingerprints of everything that feeds into bundle output but isn't
+/// covered by the entry files' own hashes.
+///
+/// Grouped into a struct rather than passed positionally: all four are the same type,
+/// so naming them at the call site is the only thing keeping them apart.
+pub struct CachedBundleDependencies<'a> {
+    /// Files referenced via `url()` in CSS (fonts, images).
+    pub css_urls: &'a FxHashMap<PathBuf, AssetFileFingerprint>,
+    /// Files Rolldown emitted as separate assets (WASM, images, fonts).
+    pub script_assets: &'a FxHashMap<PathBuf, AssetFileFingerprint>,
+    /// The entry scripts' transitive `import` graph.
+    pub script_modules: &'a FxHashMap<PathBuf, AssetFileFingerprint>,
+    /// Stylesheets pulled in via `@import`.
+    pub style_imports: &'a FxHashMap<PathBuf, AssetFileFingerprint>,
+}
+
 /// Check whether rebundling is needed by comparing asset sets and dependency fingerprints.
 pub fn needs_rebundle(
     cached_scripts: &[SerializedAssetRef],
     cached_styles: &[SerializedAssetRef],
     current_scripts: &FxHashSet<SerializedAssetRef>,
     current_styles: &FxHashSet<SerializedAssetRef>,
-    cached_css_deps: &FxHashMap<PathBuf, AssetFileFingerprint>,
-    cached_script_asset_deps: &FxHashMap<PathBuf, AssetFileFingerprint>,
+    cached_dependencies: &CachedBundleDependencies<'_>,
 ) -> bool {
     fn sets_differ(cached: &[SerializedAssetRef], current: &FxHashSet<SerializedAssetRef>) -> bool {
         cached.len() != current.len() || cached.iter().any(|item| !current.contains(item))
@@ -549,14 +574,20 @@ pub fn needs_rebundle(
         })
     }
 
-    // A changed CSS url() target or Rolldown-emitted asset changes the next bundle's
-    // output bytes, so we must re-bundle to pick it up.
-    if any_fingerprint_changed(cached_css_deps) || any_fingerprint_changed(cached_script_asset_deps)
-    {
-        return true;
-    }
+    // A changed CSS url() target, Rolldown-emitted asset, imported JS module or
+    // `@import`-ed stylesheet changes the next bundle's output bytes, so we must
+    // re-bundle to pick it up. The entry-file hashes above can't see any of these.
+    let CachedBundleDependencies {
+        css_urls,
+        script_assets,
+        script_modules,
+        style_imports,
+    } = cached_dependencies;
 
-    false
+    any_fingerprint_changed(css_urls)
+        || any_fingerprint_changed(script_assets)
+        || any_fingerprint_changed(script_modules)
+        || any_fingerprint_changed(style_imports)
 }
 
 /// Compute incremental state from a previously loaded cache and current content.
@@ -848,16 +879,19 @@ mod tests {
         let current_scripts: FxHashSet<SerializedAssetRef> = scripts.iter().cloned().collect();
         let current_styles: FxHashSet<SerializedAssetRef> = FxHashSet::default();
 
-        let no_css_deps = FxHashMap::default();
-        let no_script_asset_deps = FxHashMap::default();
+        let no_deps = FxHashMap::default();
 
         assert!(!needs_rebundle(
             &scripts,
             &styles,
             &current_scripts,
             &current_styles,
-            &no_css_deps,
-            &no_script_asset_deps,
+            &CachedBundleDependencies {
+                css_urls: &no_deps,
+                script_assets: &no_deps,
+                script_modules: &no_deps,
+                style_imports: &no_deps,
+            },
         ));
 
         // Add a new script
@@ -872,8 +906,64 @@ mod tests {
             &styles,
             &new_scripts,
             &current_styles,
-            &no_css_deps,
-            &no_script_asset_deps,
+            &CachedBundleDependencies {
+                css_urls: &no_deps,
+                script_assets: &no_deps,
+                script_modules: &no_deps,
+                style_imports: &no_deps,
+            },
+        ));
+    }
+
+    #[test]
+    fn test_needs_rebundle_on_changed_module_dependency() {
+        let dir = tempfile::tempdir().unwrap();
+        let helper = dir.path().join("helper.js");
+        fs::write(&helper, "export const marker = 1;").unwrap();
+
+        let entry = vec![SerializedAssetRef {
+            path: dir.path().join("entry.js"),
+            hash: "abc".to_string(),
+        }];
+        let current_entry: FxHashSet<SerializedAssetRef> = entry.iter().cloned().collect();
+        let no_styles = FxHashSet::default();
+        let empty = FxHashMap::default();
+
+        let mut module_deps = FxHashMap::default();
+        module_deps.insert(
+            helper.clone(),
+            AssetFileFingerprint::from_path(&helper).unwrap(),
+        );
+
+        // Unchanged import graph: nothing to do.
+        assert!(!needs_rebundle(
+            &entry,
+            &[],
+            &current_entry,
+            &no_styles,
+            &CachedBundleDependencies {
+                css_urls: &empty,
+                script_assets: &empty,
+                script_modules: &module_deps,
+                style_imports: &empty,
+            },
+        ));
+
+        // The entry is untouched, but the module it imports changed. Vary the length so
+        // the check trips on size even where mtime granularity is coarse.
+        fs::write(&helper, "export const marker = 22222;").unwrap();
+
+        assert!(needs_rebundle(
+            &entry,
+            &[],
+            &current_entry,
+            &no_styles,
+            &CachedBundleDependencies {
+                css_urls: &empty,
+                script_assets: &empty,
+                script_modules: &module_deps,
+                style_imports: &empty,
+            },
         ));
     }
 

--- a/crates/maudit/src/build/cache.rs
+++ b/crates/maudit/src/build/cache.rs
@@ -87,14 +87,12 @@ pub struct BuildCache {
     /// bytes even when no JS source changed, so we must re-bundle.
     #[serde(default)]
     pub script_asset_dependencies: FxHashMap<PathBuf, AssetFileFingerprint>,
-    /// Fingerprints of every on-disk module Rolldown inlined into a chunk, i.e. the
-    /// entry's transitive `import` graph. The entry script's own hash only covers the
-    /// entry file, so without this an edit to an imported module is invisible.
+    /// The entry scripts' transitive `import` graph. An entry's own hash covers only
+    /// the entry file, so without this an edit to an imported module is invisible.
     #[serde(default)]
     pub script_module_dependencies: FxHashMap<PathBuf, AssetFileFingerprint>,
-    /// Fingerprints of CSS files pulled in via `@import`. Same blind spot as
-    /// `script_module_dependencies`: the stylesheet's hash covers only the entry file,
-    /// and `css_url_dependencies` only covers `url()` targets.
+    /// Stylesheets pulled in via `@import`. Same blind spot as
+    /// `script_module_dependencies`; `css_url_dependencies` only covers `url()` targets.
     #[serde(default)]
     pub style_import_dependencies: FxHashMap<PathBuf, AssetFileFingerprint>,
     /// Persisted asset hash cache: path → list of (options_hash, asset_hash, mtime, size).
@@ -533,19 +531,12 @@ pub fn find_stale_static_files(
         .collect()
 }
 
-/// The cached fingerprints of everything that feeds into bundle output but isn't
-/// covered by the entry files' own hashes.
-///
-/// Grouped into a struct rather than passed positionally: all four are the same type,
-/// so naming them at the call site is the only thing keeping them apart.
+/// Fingerprints of everything feeding into bundle output that the entry files' own
+/// hashes don't cover. Named fields because all four are the same type.
 pub struct CachedBundleDependencies<'a> {
-    /// Files referenced via `url()` in CSS (fonts, images).
     pub css_urls: &'a FxHashMap<PathBuf, AssetFileFingerprint>,
-    /// Files Rolldown emitted as separate assets (WASM, images, fonts).
     pub script_assets: &'a FxHashMap<PathBuf, AssetFileFingerprint>,
-    /// The entry scripts' transitive `import` graph.
     pub script_modules: &'a FxHashMap<PathBuf, AssetFileFingerprint>,
-    /// Stylesheets pulled in via `@import`.
     pub style_imports: &'a FxHashMap<PathBuf, AssetFileFingerprint>,
 }
 
@@ -574,9 +565,7 @@ pub fn needs_rebundle(
         })
     }
 
-    // A changed CSS url() target, Rolldown-emitted asset, imported JS module or
-    // `@import`-ed stylesheet changes the next bundle's output bytes, so we must
-    // re-bundle to pick it up. The entry-file hashes above can't see any of these.
+    // None of these are visible to the entry-file hashes above.
     let CachedBundleDependencies {
         css_urls,
         script_assets,
@@ -935,7 +924,6 @@ mod tests {
             AssetFileFingerprint::from_path(&helper).unwrap(),
         );
 
-        // Unchanged import graph: nothing to do.
         assert!(!needs_rebundle(
             &entry,
             &[],
@@ -949,8 +937,7 @@ mod tests {
             },
         ));
 
-        // The entry is untouched, but the module it imports changed. Vary the length so
-        // the check trips on size even where mtime granularity is coarse.
+        // Differing length, so the check trips on size even where mtime is coarse.
         fs::write(&helper, "export const marker = 22222;").unwrap();
 
         assert!(needs_rebundle(

--- a/crates/maudit/tests/incremental.rs
+++ b/crates/maudit/tests/incremental.rs
@@ -99,6 +99,20 @@ impl Route for ImagePage {
 static STYLE_PATH_1: Mutex<Option<PathBuf>> = Mutex::new(None);
 static STYLE_PATH_2: Mutex<Option<PathBuf>> = Mutex::new(None);
 static STYLE_PATH_3: Mutex<Option<PathBuf>> = Mutex::new(None);
+static SCRIPT_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+#[route("/scripted")]
+pub struct ScriptedPage;
+
+impl Route for ScriptedPage {
+    fn render(&self, ctx: &mut PageContext) -> impl Into<RenderResult> {
+        let script_path = SCRIPT_PATH.lock().unwrap().clone().unwrap();
+        ctx.assets
+            .include_script(&script_path)
+            .expect("Failed to include script");
+        "<html><head></head><body><h1>Scripted</h1></body></html>"
+    }
+}
 
 #[route("/styled")]
 pub struct StyledPage;
@@ -2803,5 +2817,169 @@ fn test_style_dropped_from_page_clears_url_from_html() {
         !html_without_style.contains("__maudit_pending__"),
         "build 2: placeholder URL must not appear, got:\n{}",
         html_without_style
+    );
+}
+
+fn routes_with_scripted() -> &'static [&'static dyn FullRoute] {
+    &[&IndexPage, &AboutPage, &ArticlePage, &ScriptedPage]
+}
+
+/// Every emitted .js bundle in the output assets dir, concatenated.
+fn read_bundled_js(tmp: &Path) -> String {
+    let assets_dir = tmp.join("dist/_maudit");
+    let mut out = String::new();
+    if let Ok(entries) = fs::read_dir(&assets_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|e| e == "js") {
+                out.push_str(&fs::read_to_string(&path).unwrap_or_default());
+            }
+        }
+    }
+    out
+}
+
+#[test]
+#[serial]
+fn test_script_entry_change_triggers_rebundle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let content_dir = tmp.path().join("content");
+    fs::create_dir_all(content_dir.join("articles")).unwrap();
+    write_markdown(
+        &content_dir.join("articles"),
+        "first.md",
+        "First Post",
+        "The first post",
+        "Hello world",
+    );
+
+    let entry = tmp.path().join("entry.js");
+    fs::write(&entry, "console.log(\"ENTRY_ONE\");").unwrap();
+    *SCRIPT_PATH.lock().unwrap() = Some(entry.clone());
+
+    coronate(
+        routes_with_scripted(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+    assert!(read_bundled_js(tmp.path()).contains("ENTRY_ONE"));
+
+    fs::write(&entry, "console.log(\"ENTRY_TWO\");").unwrap();
+
+    coronate(
+        routes_with_scripted(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+    assert!(
+        read_bundled_js(tmp.path()).contains("ENTRY_TWO"),
+        "editing the entry script must re-bundle"
+    );
+}
+
+#[test]
+#[serial]
+fn test_script_import_change_triggers_rebundle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let content_dir = tmp.path().join("content");
+    fs::create_dir_all(content_dir.join("articles")).unwrap();
+    write_markdown(
+        &content_dir.join("articles"),
+        "first.md",
+        "First Post",
+        "The first post",
+        "Hello world",
+    );
+
+    // The entry never changes; only the module it imports does.
+    let entry = tmp.path().join("entry.js");
+    let helper = tmp.path().join("helper.js");
+    fs::write(
+        &entry,
+        "import { marker } from \"./helper.js\";\nconsole.log(marker);",
+    )
+    .unwrap();
+    fs::write(&helper, "export const marker = \"MARKER_ONE\";").unwrap();
+    *SCRIPT_PATH.lock().unwrap() = Some(entry.clone());
+
+    coronate(
+        routes_with_scripted(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+    assert!(read_bundled_js(tmp.path()).contains("MARKER_ONE"));
+
+    fs::write(&helper, "export const marker = \"MARKER_TWO\";").unwrap();
+
+    coronate(
+        routes_with_scripted(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+    assert!(
+        read_bundled_js(tmp.path()).contains("MARKER_TWO"),
+        "editing an imported module must re-bundle the entry that imports it"
+    );
+}
+
+/// Every emitted .css bundle in the output assets dir, concatenated.
+fn read_bundled_css(tmp: &Path) -> String {
+    let assets_dir = tmp.join("dist/_maudit");
+    let mut out = String::new();
+    if let Ok(entries) = fs::read_dir(&assets_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|e| e == "css") {
+                out.push_str(&fs::read_to_string(&path).unwrap_or_default());
+            }
+        }
+    }
+    out
+}
+
+#[test]
+#[serial]
+fn test_style_import_change_triggers_rebundle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let content_dir = tmp.path().join("content");
+    fs::create_dir_all(content_dir.join("articles")).unwrap();
+    write_markdown(
+        &content_dir.join("articles"),
+        "first.md",
+        "First Post",
+        "The first post",
+        "Hello world",
+    );
+
+    // The entry stylesheet never changes; only the partial it @imports does.
+    let entry = tmp.path().join("main.css");
+    let partial = tmp.path().join("_partial.css");
+    fs::write(&entry, "@import \"_partial.css\";\nbody { color: blue; }").unwrap();
+    fs::write(&partial, "h1::after { content: \"MARKER_ONE\"; }").unwrap();
+    *STYLE_PATH_1.lock().unwrap() = Some(entry.clone());
+
+    coronate(
+        routes_with_styled1(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+    assert!(read_bundled_css(tmp.path()).contains("MARKER_ONE"));
+
+    fs::write(&partial, "h1::after { content: \"MARKER_TWO\"; }").unwrap();
+
+    coronate(
+        routes_with_styled1(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+    assert!(
+        read_bundled_css(tmp.path()).contains("MARKER_TWO"),
+        "editing an @import-ed partial must re-bundle the stylesheet that imports it"
     );
 }


### PR DESCRIPTION
Incremental builds only fingerprinted script and style *entry* files, so editing a module imported by an `include_script` entry (or a CSS partial pulled in via `@import`) left the cache thinking nothing had changed, and the build served a stale bundle.

Bundling now also fingerprints each chunk's source module graph and the `@import` graph, so a change to an imported file triggers a rebundle.

`d437432` covered a neighbouring case — assets Rolldown emits separately, like fonts and WASM — but imported JS modules are inlined into a chunk rather than emitted as assets, so they were never tracked.

Adds regression tests for both the JS and CSS cases.