### PR TITLE
feat(build): add BuildValue for values computed once per build

### DIFF
--- a/.sampo/changesets/nifty-build-values.md
+++ b/.sampo/changesets/nifty-build-values.md
@@ -1,0 +1,7 @@
+---
+cargo/maudit: minor
+---
+
+Adds `BuildValue`: a value computed once per build from content and shared across every page that reads it with `ctx.build_value(&MY_VALUE)`, with its content dependencies tracked so readers re-render when its inputs change.
+
+Removes the unused `assets()` method from the `ContentContext` trait, and `PageContext::from_static_route` / `from_dynamic_route` now take a `&BuildValueStore` — both only affect code that drives the build loop directly instead of going through `coronate()`.

--- a/crates/maudit/src/build.rs
+++ b/crates/maudit/src/build.rs
@@ -402,6 +402,8 @@ pub async fn build(
         None
     };
 
+    let build_value_store = crate::build_value::BuildValueStore::default();
+
     // Serial page rendering loop.
     for route in routes {
         let cached_route = CachedRoute::new(*route);
@@ -475,6 +477,7 @@ pub async fn build(
                         &url,
                         &options.base_url,
                         None,
+                        &build_value_store,
                     );
                     let result = route.build(&mut page_ctx)?;
                     let access_log = page_ctx.take_access_log();
@@ -590,6 +593,7 @@ pub async fn build(
                             &url,
                             &options.base_url,
                             None,
+                            &build_value_store,
                         );
                         let content = route.build(&mut page_ctx)?;
                         let mut access_log = page_ctx.take_access_log();
@@ -664,6 +668,7 @@ pub async fn build(
                             &url,
                             &options.base_url,
                             None,
+                            &build_value_store,
                         ))?;
 
                         write_route_file(
@@ -760,6 +765,7 @@ pub async fn build(
                     &url,
                     &options.base_url,
                     Some(variant_id.clone()),
+                    &build_value_store,
                 );
                 let result = route.build(&mut page_ctx)?;
                 let access_log = page_ctx.take_access_log();
@@ -880,6 +886,7 @@ pub async fn build(
                             &url,
                             &options.base_url,
                             Some(variant_id.clone()),
+                            &build_value_store,
                         );
                         let content = route.build(&mut page_ctx)?;
                         let mut access_log = page_ctx.take_access_log();
@@ -950,6 +957,7 @@ pub async fn build(
                             &url,
                             &options.base_url,
                             Some(variant_id.clone()),
+                            &build_value_store,
                         ))?;
 
                         write_route_file(

--- a/crates/maudit/src/build_value.rs
+++ b/crates/maudit/src/build_value.rs
@@ -1,0 +1,232 @@
+//! Build-scoped derived values: data computed once per build from content and shared
+//! across every page that reads it.
+//!
+//! A [`BuildValue`] replaces the fragile pattern of one route computing something during
+//! its `render()` and stashing it in a global for other routes to read. On incremental
+//! builds the producing route can be served from cache — skipping its `render()` — which
+//! leaves the global unset and breaks its readers. A build value is instead computed
+//! lazily *on read*, memoized for the rest of the build, and — crucially — records its own
+//! content dependencies onto every page that reads it, so those pages are re-rendered
+//! exactly when the value's inputs change.
+//!
+//! ## Example
+//! ```rust
+//! use maudit::route::prelude::*;
+//! use maudit::build_value::BuildValue;
+//! # use maudit::content::markdown_entry;
+//! # #[markdown_entry]
+//! # pub struct Article { pub title: String }
+//!
+//! static ARTICLE_COUNT: BuildValue<usize> = BuildValue::new(|ctx| {
+//!     ctx.content::<Article>("articles").entries().count()
+//! });
+//!
+//! #[route("/")]
+//! pub struct Index;
+//! impl Route for Index {
+//!     fn render(&self, ctx: &mut PageContext) -> impl Into<RenderResult> {
+//!         format!("{} articles", ctx.build_value(&ARTICLE_COUNT))
+//!     }
+//! }
+//! ```
+
+use std::any::Any;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use rustc_hash::FxHashMap;
+
+use crate::content::tracked::{ContentAccessLog, TrackedContentSource};
+use crate::content::{ContentContext, ContentSources};
+
+/// A value derived once per build from content, read by any number of pages.
+///
+/// Declare it as a `static` with a non-capturing closure that reads everything it needs
+/// from its [`DerivedContext`], then read it from a route with
+/// [`PageContext::build_value`](crate::route::PageContext::build_value). The closure runs
+/// at most once per build (the first time any page reads it) and its result is shared.
+pub struct BuildValue<T> {
+    compute: fn(&mut DerivedContext) -> T,
+}
+
+impl<T> BuildValue<T> {
+    /// Create a build value from a pure computation over content. The closure must not
+    /// capture state (so it can live in a `static`); read inputs from the context instead.
+    pub const fn new(compute: fn(&mut DerivedContext) -> T) -> Self {
+        Self { compute }
+    }
+}
+
+/// Per-build memoization store for [`BuildValue`]s. Created once at the start of a build
+/// and shared (by reference) with every [`PageContext`](crate::route::PageContext).
+///
+/// [`coronate`](crate::coronate) manages one automatically; you only construct this
+/// directly when writing a custom build loop.
+#[derive(Default)]
+pub struct BuildValueStore {
+    cache: RefCell<FxHashMap<usize, CachedBuildValue>>,
+}
+
+struct CachedBuildValue {
+    value: Rc<dyn Any>,
+    deps: ContentAccessLog,
+}
+
+/// Context handed to a [`BuildValue`]'s compute closure. Exposes tracked content access
+/// (and nested build values), but deliberately no asset access — a build value is pure
+/// derived data; anything that emits assets belongs to a route's `render()`.
+pub struct DerivedContext<'a> {
+    content: &'a ContentSources,
+    access_log: Rc<RefCell<ContentAccessLog>>,
+    store: &'a BuildValueStore,
+}
+
+impl<'a> DerivedContext<'a> {
+    /// Get a tracked content source by name. Reads are recorded as the build value's
+    /// dependencies and replayed onto every page that reads the value.
+    pub fn content<T: 'static>(&self, name: &str) -> TrackedContentSource<'a, T> {
+        TrackedContentSource {
+            inner: self.content.get_source::<T>(name),
+            source_name: name.to_string(),
+            log: self.access_log.clone(),
+        }
+    }
+
+    /// Read another build value from within this one. Its dependencies fold into this
+    /// value's dependencies.
+    pub fn build_value<T: 'static>(&self, def: &'static BuildValue<T>) -> Rc<T> {
+        compute(def, self.content, self.store, &self.access_log)
+    }
+}
+
+impl ContentContext for DerivedContext<'_> {
+    fn content(&self) -> &ContentSources {
+        self.content
+    }
+}
+
+/// Resolve a build value: return the memoized result if present, otherwise compute it
+/// with a fresh dependency log. Either way, replay the value's dependencies onto
+/// `reader_log` so the reading page depends on whatever the value was computed from.
+pub(crate) fn compute<T: 'static>(
+    def: &'static BuildValue<T>,
+    content: &ContentSources,
+    store: &BuildValueStore,
+    reader_log: &Rc<RefCell<ContentAccessLog>>,
+) -> Rc<T> {
+    let key = def as *const BuildValue<T> as usize;
+
+    {
+        let cache = store.cache.borrow();
+        if let Some(cached) = cache.get(&key) {
+            reader_log.borrow_mut().merge_all(&cached.deps);
+            return cached
+                .value
+                .clone()
+                .downcast::<T>()
+                .expect("build value cached under a mismatched type");
+        }
+    }
+
+    // Compute with a fresh log so the closure's reads become *this value's* deps rather
+    // than the current reader's. Nested build_value() calls fold their deps in here too.
+    let fresh_log = Rc::new(RefCell::new(ContentAccessLog::new()));
+    let mut derived = DerivedContext {
+        content,
+        access_log: fresh_log.clone(),
+        store,
+    };
+    let value: Rc<T> = Rc::new((def.compute)(&mut derived));
+    let deps = fresh_log.take();
+
+    reader_log.borrow_mut().merge_all(&deps);
+    store.cache.borrow_mut().insert(
+        key,
+        CachedBuildValue {
+            value: value.clone(),
+            deps,
+        },
+    );
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::content::{ContentEntry, ContentSource, ContentSources, Entry};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn sources() -> ContentSources {
+        let source = ContentSource::<String>::new(
+            "things",
+            Box::new(|| {
+                vec![
+                    Entry::<String>::create("a".into(), None, None, "one".into(), vec![]),
+                    Entry::<String>::create("b".into(), None, None, "two".into(), vec![]),
+                ]
+            }),
+        );
+        let mut sources = ContentSources::new(vec![Box::new(source)]);
+        sources.init_all();
+        sources
+    }
+
+    static COMPUTE_COUNT: AtomicUsize = AtomicUsize::new(0);
+    static THING_COUNT: BuildValue<usize> = BuildValue::new(|ctx| {
+        COMPUTE_COUNT.fetch_add(1, Ordering::SeqCst);
+        ctx.content::<String>("things").entries().count()
+    });
+
+    #[test]
+    fn computes_once_and_replays_deps() {
+        let sources = sources();
+        let store = BuildValueStore::default();
+        let reader = Rc::new(RefCell::new(ContentAccessLog::new()));
+
+        COMPUTE_COUNT.store(0, Ordering::SeqCst);
+        let first = compute(&THING_COUNT, &sources, &store, &reader);
+        let second = compute(&THING_COUNT, &sources, &store, &reader);
+
+        assert_eq!(*first, 2);
+        assert_eq!(*second, 2);
+        // Memoized: the closure ran exactly once across both reads.
+        assert_eq!(COMPUTE_COUNT.load(Ordering::SeqCst), 1);
+
+        // The value iterated "things", so each reader now depends on that source.
+        let log = reader.borrow();
+        assert_eq!(
+            log.sources_iterated
+                .iter()
+                .filter(|s| s.as_str() == "things")
+                .count(),
+            2,
+            "the source dep should be replayed onto every read"
+        );
+    }
+
+    // Separate build values from THING_COUNT so this test never touches COMPUTE_COUNT
+    // (unit tests run in parallel; a shared counter would race).
+    static INNER_COUNT: BuildValue<usize> =
+        BuildValue::new(|ctx| ctx.content::<String>("things").entries().count());
+    static DERIVED_LEN: BuildValue<usize> =
+        BuildValue::new(|ctx| *ctx.build_value(&INNER_COUNT) + 10);
+
+    #[test]
+    fn nested_build_value_folds_in_deps() {
+        let sources = sources();
+        let store = BuildValueStore::default();
+        let reader = Rc::new(RefCell::new(ContentAccessLog::new()));
+
+        let value = compute(&DERIVED_LEN, &sources, &store, &reader);
+        assert_eq!(*value, 12);
+
+        // The nested value iterated "things", so the outer reader inherits that dep.
+        assert!(
+            reader
+                .borrow()
+                .sources_iterated
+                .iter()
+                .any(|s| s == "things")
+        );
+    }
+}

--- a/crates/maudit/src/content.rs
+++ b/crates/maudit/src/content.rs
@@ -10,10 +10,7 @@ pub mod markdown;
 mod slugger;
 pub mod tracked;
 
-use crate::{
-    assets::RouteAssets,
-    route::{DynamicRouteContext, PageContext, PageParams},
-};
+use crate::route::{DynamicRouteContext, PageContext, PageParams};
 pub use markdown::{
     components::{
         BlockQuoteKind, BlockquoteComponent, CodeComponent, EmphasisComponent, HardBreakComponent,
@@ -174,29 +171,22 @@ pub trait ContentEntry<T> {
 
 impl<T> ContentEntry<T> for Entry<T> {}
 
-/// Trait for contexts that can provide access to content
+/// Trait for contexts that can read content: the render-time [`PageContext`], the
+/// enumeration-time [`DynamicRouteContext`], and the [`DerivedContext`](crate::build_value::DerivedContext)
+/// used to compute [`BuildValue`](crate::build_value::BuildValue)s.
 pub trait ContentContext {
     fn content(&self) -> &ContentSources;
-    fn assets(&mut self) -> &mut RouteAssets;
 }
 
 impl ContentContext for PageContext<'_> {
     fn content(&self) -> &ContentSources {
         self.content
     }
-
-    fn assets(&mut self) -> &mut RouteAssets {
-        self.assets
-    }
 }
 
 impl ContentContext for DynamicRouteContext<'_> {
     fn content(&self) -> &ContentSources {
         self.content
-    }
-
-    fn assets(&mut self) -> &mut RouteAssets {
-        self.assets
     }
 }
 

--- a/crates/maudit/src/content/markdown/shortcodes_tests.rs
+++ b/crates/maudit/src/content/markdown/shortcodes_tests.rs
@@ -60,6 +60,7 @@ mod tests {
         use crate::{assets::RouteAssets, content::ContentSources};
 
         let content_sources = ContentSources::new(vec![]);
+        let build_values = crate::build_value::BuildValueStore::default();
         let mut page_assets = RouteAssets::new(
             &RouteAssetsOptions {
                 assets_dir: "assets".into(),
@@ -80,6 +81,7 @@ mod tests {
             access_log: std::rc::Rc::new(std::cell::RefCell::new(
                 crate::content::tracked::ContentAccessLog::new(),
             )),
+            build_values: &build_values,
         };
 
         f(&mut ctx)

--- a/crates/maudit/src/content/tracked.rs
+++ b/crates/maudit/src/content/tracked.rs
@@ -29,6 +29,16 @@ impl ContentAccessLog {
     pub fn merge_entries_read(&mut self, other: &ContentAccessLog) {
         self.entries_read.extend(other.entries_read.iter().cloned());
     }
+
+    /// Merge every dependency from `other` into this log — both specific entry reads
+    /// and full-source iterations. Used to replay a [`BuildValue`](crate::build_value::BuildValue)'s
+    /// own content dependencies onto each page that reads it, so the reader is
+    /// re-rendered whenever the value's inputs change.
+    pub(crate) fn merge_all(&mut self, other: &ContentAccessLog) {
+        self.entries_read.extend(other.entries_read.iter().cloned());
+        self.sources_iterated
+            .extend(other.sources_iterated.iter().cloned());
+    }
 }
 
 /// A wrapper around [`ContentSource`] that records all accesses

--- a/crates/maudit/src/lib.rs
+++ b/crates/maudit/src/lib.rs
@@ -7,6 +7,7 @@
 
 // Modules the end-user will interact directly or indirectly with
 pub mod assets;
+pub mod build_value;
 pub mod content;
 pub mod errors;
 pub mod route;

--- a/crates/maudit/src/route.rs
+++ b/crates/maudit/src/route.rs
@@ -319,6 +319,7 @@ pub struct PageContext<'a> {
     pub variant: Option<String>,
     pub(crate) access_log:
         std::rc::Rc<std::cell::RefCell<crate::content::tracked::ContentAccessLog>>,
+    pub(crate) build_values: &'a crate::build_value::BuildValueStore,
 }
 
 impl<'a> PageContext<'a> {
@@ -328,6 +329,7 @@ impl<'a> PageContext<'a> {
         current_path: &'a String,
         base_url: &'a Option<String>,
         variant: Option<String>,
+        build_values: &'a crate::build_value::BuildValueStore,
     ) -> Self {
         Self {
             params: &(),
@@ -340,6 +342,7 @@ impl<'a> PageContext<'a> {
             access_log: std::rc::Rc::new(std::cell::RefCell::new(
                 crate::content::tracked::ContentAccessLog::new(),
             )),
+            build_values,
         }
     }
 
@@ -350,6 +353,7 @@ impl<'a> PageContext<'a> {
         current_path: &'a String,
         base_url: &'a Option<String>,
         variant: Option<String>,
+        build_values: &'a crate::build_value::BuildValueStore,
     ) -> Self {
         Self {
             params: dynamic_page.1.as_ref(),
@@ -362,6 +366,7 @@ impl<'a> PageContext<'a> {
             access_log: std::rc::Rc::new(std::cell::RefCell::new(
                 crate::content::tracked::ContentAccessLog::new(),
             )),
+            build_values,
         }
     }
 
@@ -378,6 +383,16 @@ impl<'a> PageContext<'a> {
 
     pub(crate) fn take_access_log(&self) -> crate::content::tracked::ContentAccessLog {
         self.access_log.take()
+    }
+
+    /// Read a [`BuildValue`](crate::build_value::BuildValue): a value computed once per
+    /// build from content and shared across pages. The value's own content dependencies
+    /// are recorded onto this page, so the page re-renders when those inputs change.
+    pub fn build_value<T: 'static>(
+        &self,
+        def: &'static crate::build_value::BuildValue<T>,
+    ) -> std::rc::Rc<T> {
+        crate::build_value::compute(def, self.content, self.build_values, &self.access_log)
     }
 
     pub fn params<T: 'static + Clone>(&self) -> T {
@@ -1019,6 +1034,7 @@ pub mod prelude {
         Asset, Image, ImageFormat, ImageOptions, ImagePlaceholder, RenderWithAlt, Script, Style,
         StyleOptions,
     };
+    pub use crate::build_value::BuildValue;
     pub use crate::content::{ContentContext, ContentEntry, Entry, EntryInner, MarkdownContent};
     pub use maudit_macros::{Params, route};
 }

--- a/crates/maudit/tests/incremental.rs
+++ b/crates/maudit/tests/incremental.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
+use maudit::build_value::BuildValue;
 use maudit::content::markdown_entry;
 use maudit::content::{ContentSource, ContentSources, glob_markdown};
 use maudit::route::prelude::*;
@@ -240,6 +241,61 @@ impl Route<ProjectParams> for ProjectPage {
             data.title, data.description
         )
     }
+}
+
+/// Read by both routes below, so both must inherit its `articles` dependency.
+static ARTICLE_DIGEST: BuildValue<String> = BuildValue::new(|ctx| {
+    let articles = ctx.content::<ArticleContent>("articles");
+    let mut titles: Vec<String> = Vec::new();
+    for entry in articles.entries() {
+        titles.push(entry.data(ctx).title.clone());
+    }
+    titles.sort();
+    titles.join("|")
+});
+
+static CONSUMER_STYLE_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+/// Reads the digest but has no other inputs, so it goes cached on an incremental build.
+#[route("/data.json")]
+pub struct DataRoute;
+
+impl Route for DataRoute {
+    fn render(&self, ctx: &mut PageContext) -> impl Into<RenderResult> {
+        let digest = ctx.build_value(&ARTICLE_DIGEST);
+        format!("{{\"digest\":\"{}\"}}", digest)
+    }
+}
+
+/// The style lets this route be dirtied without touching any content.
+#[route("/consumer")]
+pub struct ConsumerRoute;
+
+impl Route for ConsumerRoute {
+    fn render(&self, ctx: &mut PageContext) -> impl Into<RenderResult> {
+        let style_path = CONSUMER_STYLE_PATH.lock().unwrap().clone().unwrap();
+        ctx.assets
+            .include_style(&style_path)
+            .expect("failed to include style");
+        let digest = ctx.build_value(&ARTICLE_DIGEST);
+        format!(
+            "<html><head></head><body data-digest=\"{}\"><h1>Consumer</h1></body></html>",
+            digest
+        )
+    }
+}
+
+fn build_value_routes() -> &'static [&'static dyn FullRoute] {
+    &[&DataRoute, &ConsumerRoute]
+}
+
+fn page_is_cached(output: &maudit::BuildOutput, path_substr: &str) -> bool {
+    output
+        .pages
+        .iter()
+        .find(|p| p.file_path.contains(path_substr))
+        .unwrap_or_else(|| panic!("no page with path containing {path_substr:?}"))
+        .cached
 }
 
 fn write_markdown(dir: &Path, filename: &str, title: &str, description: &str, body: &str) {
@@ -2981,5 +3037,173 @@ fn test_style_import_change_triggers_rebundle() {
     assert!(
         read_bundled_css(tmp.path()).contains("MARKER_TWO"),
         "editing an @import-ed partial must re-bundle the stylesheet that imports it"
+    );
+}
+
+/// Regression for the cached-producer-skips-side-effect trap: when the route that
+/// "produces" a shared value is cached, a dirty page reading the value must still get it.
+#[test]
+#[serial]
+fn test_build_value_available_when_producer_route_is_cached() {
+    let tmp = tempfile::tempdir().unwrap();
+    let content_dir = tmp.path().join("content");
+    fs::create_dir_all(content_dir.join("articles")).unwrap();
+    write_markdown(
+        &content_dir.join("articles"),
+        "first.md",
+        "First",
+        "d1",
+        "Body",
+    );
+    write_markdown(
+        &content_dir.join("articles"),
+        "second.md",
+        "Second",
+        "d2",
+        "Body",
+    );
+
+    let style_file = tmp.path().join("consumer.css");
+    fs::write(&style_file, "body { color: red; }").unwrap();
+    *CONSUMER_STYLE_PATH.lock().unwrap() = Some(style_file.clone());
+
+    let _ = coronate(
+        build_value_routes(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+
+    // Change ONLY the consumer's style, so no content is dirty.
+    fs::write(&style_file, "body { color: blue; }").unwrap();
+
+    let output = coronate(
+        build_value_routes(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+
+    assert!(
+        page_is_cached(&output, "data.json"),
+        "data.json should be cached — its inputs are unchanged"
+    );
+    assert!(
+        !page_is_cached(&output, "consumer"),
+        "consumer should re-render (its style changed)"
+    );
+
+    let html = fs::read_to_string(tmp.path().join("dist/consumer/index.html")).unwrap();
+    assert!(
+        html.contains("data-digest=\"First|Second\""),
+        "digest must be present even though the producer route was cached, got:\n{html}"
+    );
+}
+
+/// Editing a build value's input re-renders every page that reads it, with the new value.
+#[test]
+#[serial]
+fn test_build_value_readers_rerender_on_input_change() {
+    let tmp = tempfile::tempdir().unwrap();
+    let content_dir = tmp.path().join("content");
+    fs::create_dir_all(content_dir.join("articles")).unwrap();
+    write_markdown(
+        &content_dir.join("articles"),
+        "first.md",
+        "First",
+        "d1",
+        "Body",
+    );
+    write_markdown(
+        &content_dir.join("articles"),
+        "second.md",
+        "Second",
+        "d2",
+        "Body",
+    );
+
+    let style_file = tmp.path().join("consumer.css");
+    fs::write(&style_file, "body { color: red; }").unwrap();
+    *CONSUMER_STYLE_PATH.lock().unwrap() = Some(style_file.clone());
+
+    let _ = coronate(
+        build_value_routes(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+
+    // Change a title that feeds the digest.
+    write_markdown(
+        &content_dir.join("articles"),
+        "first.md",
+        "Zeta",
+        "d1",
+        "Body",
+    );
+
+    let output = coronate(
+        build_value_routes(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+
+    assert!(
+        !page_is_cached(&output, "data.json"),
+        "producer reads the digest, so an input change must re-render it"
+    );
+    assert!(
+        !page_is_cached(&output, "consumer"),
+        "consumer reads the digest, so an input change must re-render it"
+    );
+
+    let html = fs::read_to_string(tmp.path().join("dist/consumer/index.html")).unwrap();
+    assert!(
+        html.contains("data-digest=\"Second|Zeta\""),
+        "digest must reflect the edited title, got:\n{html}"
+    );
+}
+
+/// When nothing a build value depends on changes, its readers stay cached.
+#[test]
+#[serial]
+fn test_build_value_readers_cached_when_inputs_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let content_dir = tmp.path().join("content");
+    fs::create_dir_all(content_dir.join("articles")).unwrap();
+    write_markdown(
+        &content_dir.join("articles"),
+        "first.md",
+        "First",
+        "d1",
+        "Body",
+    );
+
+    let style_file = tmp.path().join("consumer.css");
+    fs::write(&style_file, "body { color: red; }").unwrap();
+    *CONSUMER_STYLE_PATH.lock().unwrap() = Some(style_file.clone());
+
+    let _ = coronate(
+        build_value_routes(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+
+    let output = coronate(
+        build_value_routes(),
+        make_content_sources(&content_dir),
+        build_options(tmp.path()),
+    )
+    .unwrap();
+
+    assert!(
+        page_is_cached(&output, "data.json"),
+        "no change: producer cached"
+    );
+    assert!(
+        page_is_cached(&output, "consumer"),
+        "no change: consumer cached"
     );
 }

--- a/examples/library/src/build.rs
+++ b/examples/library/src/build.rs
@@ -3,6 +3,7 @@ use std::fs;
 use maudit::{
     BuildOptions,
     assets::RouteAssets,
+    build_value::BuildValueStore,
     content::ContentSources,
     route::{DynamicRouteContext, FullRoute, PageContext, PageParams},
     routing::extract_params_from_raw_route,
@@ -22,6 +23,8 @@ pub fn build_website(
 
     // Create the assets directory if it doesn't exist.
     fs::create_dir_all(&route_assets_options.output_assets_dir)?;
+
+    let build_values = BuildValueStore::default();
 
     for route in routes {
         // Get the raw route path (e.g., "/articles/[slug]")
@@ -51,6 +54,7 @@ pub fn build_website(
                 &url,
                 &options.base_url,
                 None,
+                &build_values,
             );
 
             let content = route.build(&mut ctx)?;
@@ -96,6 +100,7 @@ pub fn build_website(
                     &url,
                     &options.base_url,
                     None,
+                    &build_values,
                 );
 
                 // Everything below here is the same as for static routes.

--- a/website/content/docs/build-values.md
+++ b/website/content/docs/build-values.md
@@ -1,0 +1,97 @@
+---
+title: "Build values"
+description: "Compute a value once per build and share it across every page that needs it."
+section: "advanced"
+---
+
+Sometimes many pages need the same value: a bit of configuration, an expensive lookup table, a cache-busting hash, an index built from your content. Recomputing it in every page is wasteful, and computing it once in a global breaks in ways that only show up on incremental builds.
+
+A build value is computed once per build and shared across every page that reads it.
+
+## Defining a build value
+
+Declare a build value as a `static` with [`BuildValue::new`](https://docs.rs/maudit/latest/maudit/build_value/struct.BuildValue.html). The closure computes the value and returns it:
+
+```rs
+use maudit::route::prelude::*;
+
+static SITE_VERSION: BuildValue<String> = BuildValue::new(|_ctx| {
+    std::env::var("SITE_VERSION").unwrap_or_else(|_| "dev".into())
+});
+```
+
+The closure can't capture anything from its surroundings, which is what lets it live in a `static`. It receives a context for reading content and other build values, but the value itself can be anything: a config string, a parsed file, a lookup table.
+
+## Reading a build value
+
+Read a build value from a route's `render` with [`PageContext#build_value`](https://docs.rs/maudit/latest/maudit/route/struct.PageContext.html). It returns an `Rc<T>`:
+
+```rs
+#[route("/")]
+pub struct Index;
+
+impl Route for Index {
+    fn render(&self, ctx: &mut PageContext) -> impl Into<RenderResult> {
+        let version = ctx.build_value(&SITE_VERSION); // Rc<String>
+
+        format!("<footer>Built from {version}</footer>")
+    }
+}
+```
+
+The closure runs at most once per build, the first time any page reads the value. Every page that reads it gets the same result.
+
+## Scoped to one build
+
+A build value is scoped to a single build. In a long-running process like `maudit dev`, each rebuild recomputes it. A plain `static` computed with `LazyLock` or `OnceLock` behaves differently: it runs once for the life of the process and never updates, so a value that should change between builds goes stale in the dev server. A build value stays correct across rebuilds.
+
+## Deriving from content
+
+If the closure reads content, Maudit tracks those reads. Every page that reads the value depends on the content the value was derived from, so incremental builds re-render exactly the right pages.
+
+The context exposes the same content API you use in pages: `entries()`, `get_entry(id)`, `get_entry_safe(id)`, and `entry.data(ctx)`.
+
+```rs
+#[markdown_entry]
+pub struct Article {
+    pub title: String,
+}
+
+static ARTICLE_TITLES: BuildValue<Vec<String>> = BuildValue::new(|ctx| {
+    let articles = ctx.content::<Article>("articles");
+
+    let mut titles: Vec<String> = Vec::new();
+    for entry in articles.entries() {
+        titles.push(entry.data(ctx).title.clone());
+    }
+    titles.sort();
+    titles
+});
+```
+
+Every page that reads `ARTICLE_TITLES` re-renders when an article changes and stays cached otherwise. You don't manage that caching yourself.
+
+A value derived from something Maudit doesn't track, like an environment variable or an external file, is still computed once per build, but its readers won't re-render if only that input changes between incremental builds. A full rebuild picks up the new value.
+
+## Globals break on incremental builds
+
+A common instinct is to compute the value in one route's `render` and stash it in a global for other routes to read. This works on a full build but breaks on incremental ones.
+
+On an incremental build, the route that computed the value can be served from cache, so Maudit skips its `render` and the global is never set. The other pages then read an empty value, or panic. It fails only on local rebuilds, and only depending on which file you last touched.
+
+Build values avoid this by being computed on read rather than as a side effect of a route's `render`. It doesn't matter which pages are cache hits; the value is computed the first time it's needed.
+
+## What a build value can and can't do
+
+Inside the closure you can read content sources and other build values (they nest, and their dependencies fold in). You can't:
+
+- Register assets like images, scripts, or styles. Those belong to a route's `render`.
+- Render a content entry's body with `entry.render(ctx)`. Rendering needs a full `PageContext`. If you need a value derived from rendered output, derive it from the inputs instead: for a cache-busting hash, hash the source data rather than the rendered HTML, which changes at the same times without the cost of rendering.
+
+Build values are read during `render`, not during `pages`.
+
+## When to reach for one
+
+Use a build value when the same value is read by several pages and isn't trivial to recompute per page: a shared config, an expensive computation, a content-derived index, a site-wide hash.
+
+For a cheap, one-page computation, compute it inline in that page instead. A build value earns its place when you want to compute something once and share it.


### PR DESCRIPTION
Adds `BuildValue`: a value computed once per build from content and shared across every page that reads it via `ctx.build_value(&MY_VALUE)`.

```rust
static ARTICLE_COUNT: BuildValue<usize> =
    BuildValue::new(|ctx| ctx.content::<Article>("articles").entries().count());

// in a routes render():
let count = ctx.build_value(&ARTICLE_COUNT);
```

This replaces the pattern of one route computing something in its `render()` and stashing it in a global for other routes to read. On incremental builds the producing route can be served from cache — skipping its `render()` — which leaves the global unset and breaks its readers. A build value is computed lazily on read, memoized for the rest of the build, and records its own content dependencies onto every page that reads it, so readers re-render exactly when the values inputs change.

Also removes the unused `assets()` method from the `ContentContext` trait, and `PageContext::from_static_route` / `from_dynamic_route` now take a `&BuildValueStore` — both only affect code that drives the build loop directly instead of going through `coronate()`.